### PR TITLE
Update mu command

### DIFF
--- a/index.org
+++ b/index.org
@@ -7151,7 +7151,8 @@ Reindex using mu, but first remove existing index for offlineimap messages:
 Ok, do index now:
 
 #+BEGIN_SRC sh
-  mu index --maildir=~/IMAP
+  mu init --maildir=~/IMAP
+  mu index
 #+END_SRC
 
 ** Mu4e tweaks


### PR DESCRIPTION
NOTE: as of mu 1.3.8, 'mu index' no longer uses the
--maildir/-m or --my-address options.

Instead, these options should be passed to 'mu init'.
See the mu-init(1) or the mu4e reference manual,
'Initializing the message store' for details.